### PR TITLE
Use wp-cli.yml instead of bash script for local wp-cli

### DIFF
--- a/bin/wp
+++ b/bin/wp
@@ -1,3 +1,0 @@
-#!/bin/bash
-DIRECTORY=${PWD##*/}
-docker-compose run --rm -w /var/www/html/${DIRECTORY} --user=www-data php wp --path=/var/www/html/${DIRECTORY}/htdocs $@

--- a/config/wp-cli/local.php
+++ b/config/wp-cli/local.php
@@ -2,7 +2,4 @@
 
 define('DB_HOST', '127.0.0.1:3306');
 
-define('DB_USER', 'wordpress');
-define('DB_PASSWORD', 'wordpress');
-
 

--- a/config/wp-cli/local.php
+++ b/config/wp-cli/local.php
@@ -1,0 +1,8 @@
+<?php
+
+define('DB_HOST', '127.0.0.1:3306');
+
+define('DB_USER', 'wordpress');
+define('DB_PASSWORD', 'wordpress');
+
+

--- a/config/wp-cli/quiet.php
+++ b/config/wp-cli/quiet.php
@@ -1,0 +1,4 @@
+<?php 
+error_reporting(0);
+@ini_set('display_errors', 0);
+define( 'WP_DEBUG', false );

--- a/wp-cli.yml
+++ b/wp-cli.yml
@@ -1,0 +1,3 @@
+require:
+  - config/wp-cli/local.php
+  - config/wp-cli/quiet.php


### PR DESCRIPTION
I was never able to get the `wp` bash script to work, but by setting up a `wp-cli.yml` file to include php files with the default mysql credentials I was able to complete normal wp-cli commands to work.