### PR TITLE
Add site and url WordPress constants

### DIFF
--- a/config/wp-config.php.inc
+++ b/config/wp-config.php.inc
@@ -2,6 +2,8 @@ define( 'WP_DEBUG', true );
 define( 'SCRIPT_DEBUG', true );
 define( 'JETPACK_DEV_DEBUG', true );
 define( 'JETPACK_STAGING_MODE', true );
+define( 'WP_HOME', 'http://{{site_name}}.dev' );
+define( 'WP_SITEURL', 'http://{{site_name}}.dev' );
 
 $redis_server = [ 'host' => 'redis' ];
 define( 'WP_CACHE_KEY_SALT', '{{site_name}}' );


### PR DESCRIPTION
It would be easier to have these constants set, as most of the sites that spin up are existing, which have set urls in the `options` table. I don't know whether PH has a variable for the local url, but `{{site_name}}` is a start. The TLD (`.dev`) is probably problematic as well as the set protocol I have (`http`). Happy to get more information or open up a dialogue.