### PR TITLE
Refer to font in a case sensitive fashion

### DIFF
--- a/commands/up.js
+++ b/commands/up.js
@@ -12,7 +12,7 @@ const upCommand = function(displayFiglet = true) {
 	}
 
 	if (displayFiglet) {
-		console.log(chalk.blue(figlet.textSync('Pilothouse', {font: 'slant'})));
+		console.log(chalk.blue(figlet.textSync('Pilothouse', {font: 'Slant'})));
 	}
 
 	run.buildRunFiles();


### PR DESCRIPTION
When running `pilothouse up` on linux, we get an error that the file `Pilothouse/node_modules/figlet/lib/../fonts/slant.flf` doesn't exit. Looking into that node module, the file is `Slant.flf` instead of `slant.flf`, which doesn't matter on OSX but matters a lot on Linux.

This fixes that error by fixing the casing of the font name.

Related to #71 